### PR TITLE
Use stable docker-java release 1.1.0 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,25 @@
     <name>Maven plugin for Docker</name>
     <url>http://www.ofbizian.com</url>
 
+    <scm>
+        <connection>scm:git:https://github.com/tcompart/docker-maven-plugin.git</connection>
+        <url>https://github.com/tcompart/docker-maven-plugin.git</url>
+        <developerConnection>scm:git:https://github.com/tcompart/docker-maven-plugin.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+    <distributionManagement>
+        <snapshotRepository>
+            <id>snapshots</id>
+            <name>Snapshots</name>
+            <url>http://devnex.rz.is24.loc/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>releases</id>
+            <name>Releases</name>
+            <url>http://devnex.rz.is24.loc/content/repositories/releases/</url>
+        </repository>
+    </distributionManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ofbizian</groupId>
     <artifactId>docker-maven-plugin</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven plugin for Docker</name>
@@ -15,7 +14,7 @@
         <connection>scm:git:https://github.com/tcompart/docker-maven-plugin.git</connection>
         <url>https://github.com/tcompart/docker-maven-plugin.git</url>
         <developerConnection>scm:git:https://github.com/tcompart/docker-maven-plugin.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>docker-maven-plugin-1.1.0</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.ofbizian</groupId>
     <artifactId>docker-maven-plugin</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Maven plugin for Docker</name>
@@ -14,7 +14,7 @@
         <connection>scm:git:https://github.com/tcompart/docker-maven-plugin.git</connection>
         <url>https://github.com/tcompart/docker-maven-plugin.git</url>
         <developerConnection>scm:git:https://github.com/tcompart/docker-maven-plugin.git</developerConnection>
-        <tag>docker-maven-plugin-1.1.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/src/main/java/com/ofbizian/plugin/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/ofbizian/plugin/docker/AbstractDockerMojo.java
@@ -34,7 +34,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     }
 
     public DockerClient getDockerClient(String url) {
-        return dockerClient != null ? dockerClient : new DockerClientImpl(url);
+        return dockerClient != null ? dockerClient : DockerClientImpl.getInstance(url);
     }
 
     public boolean isSkipStop() {


### PR DESCRIPTION
When I tried to run the docker-maven-plugin the docker-java version 0.10.1 was not found anymore. Therefore I upgraded it to 1.1.0, and had to change the creation of the DockerClient.
I would like to see this in master too :+1: 

Signed-off-by: Compart, Torsten <torsten.compart@gmail.com>