### PR TITLE
Use stable docker-java release 1.1.0 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
-            <version>0.10.1-SNAPSHOT</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/ofbizian/plugin/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/ofbizian/plugin/docker/AbstractDockerMojo.java
@@ -34,7 +34,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo {
     }
 
     public DockerClient getDockerClient(String url) {
-        return dockerClient != null ? dockerClient : new DockerClientImpl(url);
+        return dockerClient != null ? dockerClient : DockerClientImpl.getInstance(url);
     }
 
     public boolean isSkipStop() {


### PR DESCRIPTION
When I tried to run the docker-maven-plugin the docker-java version 0.10.1 was not found anymore. Therefore I upgraded it to 1.1.0, and had to change the creation of the DockerClient.
I would like to see this in master too :+1: 

Signed-off-by: Compart, Torsten torsten.compart@gmail.com
