### PR TITLE
Adding release-plugin to a maven repo - github mvn repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,25 +8,49 @@
     <version>1.1.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
+    <developers>
+        <developer>
+            <id>${owner}</id>
+            <name>Bilgin Ibryam</name>
+            <email>bibryam@apache.org</email>
+            <url>http://www.ofbizian.com</url>
+            <organization>Red Hat, Inc</organization>
+        </developer>
+    </developers>
+    
     <name>Maven plugin for Docker</name>
     <url>http://www.ofbizian.com</url>
 
+    <properties>
+        <owner>bibryam</owner>
+        <giturl>https://github.com/bibryam/docker-maven-plugin.git</giturl>
+        <!-- github server corresponds to entry in ~/.m2/settings.xml -->
+        <github.global.server>github</github.global.server>
+    </properties>
+
+    <scm>
+        <connection>scm:git:${giturl}</connection>
+        <url>${giturl}</url>
+        <developerConnection>scm:git:${giturl}</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+    
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>2.0</version>
+            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.2</version>
+            <version>3.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.21</version>
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
@@ -36,7 +60,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
+            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -91,6 +115,35 @@
                     <source>1.6</source>
                     <target>1.6</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.1</version>
+                <configuration>
+                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <version>0.11</version>
+                <configuration>
+                    <message>Maven artifacts for ${project.version}</message>  <!-- git commit message -->
+                    <noJekyll>true</noJekyll>                                  <!-- disable webpage processing -->
+                    <outputDirectory>${project.build.directory}/mvn-repo</outputDirectory> <!-- matches distribution management repository url above -->
+                    <branch>refs/heads/mvn-repo</branch>
+                    <includes><include>**/*</include></includes>
+                    <repositoryName>${project.artifactId}</repositoryName>
+                    <repositoryOwner>${owner}</repositoryOwner>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -184,4 +237,12 @@
             </build>
         </profile>
     </profiles>
+
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Temporary Staging Repository</name>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
Hi,

How about a github release plugin/repo on this site?
This pull request would enable you to release jars directly to github mvn repo with 
`mvn clean release:prepare release:perform`.

All you need is mvn settings.xml like

``` xml
<servers>
  <server>
    <id>github</id>
    <password>OAUTH2TOKEN</password>
  </server>
</servers>
```

You could then execute `mvn clean deploy`

I think this also fixes #3 

Signed-off-by: Compart, Torsten torsten.compart@gmail.com
